### PR TITLE
enclose Object.keys() in a try block

### DIFF
--- a/packages/ember-metal/lib/assign.js
+++ b/packages/ember-metal/lib/assign.js
@@ -20,7 +20,13 @@ export default function assign(original, ...args) {
     let arg = args[i];
     if (!arg) { continue; }
 
-    let updates = Object.keys(arg);
+    let updates = [];
+    
+    try{
+      updates = Object.keys(arg);
+    } catch(e){
+      throw new _emberMetalError.default('Tried to retrieve keys of a non-Object');
+    }
 
     for (let i = 0; i < updates.length; i++) {
       let prop = updates[i];


### PR DESCRIPTION
Prevent exception from firing when trying to get keys of a non-object.
This block fails only in IE.
